### PR TITLE
Corrected an example

### DIFF
--- a/mcd/mcd-seth/mcd-seth-01.md
+++ b/mcd/mcd-seth/mcd-seth-01.md
@@ -156,7 +156,7 @@ Then use the following command to use the join function, thus taking 150 BAT fro
 
 We can check the results with the contract function: `gem(bytes32 ilk,address urn)(uint256)` with.
 
-`seth --from-wei $(seth --to-dec $(seth call $MCD_VAT 'gem(bytes32,address)(uint256)' $ilk $urn)) eth`
+`seth --from-wei $(seth call $MCD_VAT 'gem(bytes32,address)(uint256)' $ilk $urn) eth`
 
 The output should look like this:
 


### PR DESCRIPTION
The existing string returned incorrect output, I inserted (what I believe is) the correct string.