### PR TITLE
Fix links

### DIFF
--- a/devtools/test-chain-guide/test-chain-guide.md
+++ b/devtools/test-chain-guide/test-chain-guide.md
@@ -489,7 +489,7 @@ In addition, you can use this [repo](https://github.com/makerdao/dss-deploy) to 
 
 ## Resources
 
-- <https://makerdao.com/documentation/>
+- <https://docs.makerdao.com/>
 - <https://docs.microsoft.com/en-us/windows/wsl/install-win10>
 - <https://dapp.tools/>
 - <https://nodejs.org>

--- a/exchanges/README.md
+++ b/exchanges/README.md
@@ -6,5 +6,5 @@ This folder contains guides specifically for exchanges seeking to integrate with
 
 If you are already familiar with Ethereum, the ERC-20 token standard, and Solidity smart contracts, you can checkout this guide for listing DAI and MKR tokens:
 
-- [Quick guide for listing DAI and MKR tokens](/exchanges/exchanges-guide-01/exchanges-guide-01.md)
+- [Quick guide for listing DAI and MKR tokens](/exchanges/exchanges-guide/exchanges-guide.md)
 


### PR DESCRIPTION
test-chain-guide.md was linking to https://makerdao.com/documentation/ which returns a 404. Now pointing to https://docs.makerdao.com/

Also fixes #86; quick start points to the correct link