### PR TITLE
Chore: update mcd-seth tutorial

### DIFF
--- a/mcd/README.md
+++ b/mcd/README.md
@@ -6,7 +6,7 @@ This repo contains guides for interacting and integrating with Multi-Collateral 
 
 - [Introduction and Overview of Maker Protocol](/mcd/mcd-101/mcd-101.md)
 - [Using MCD-CLI to create and close a Vault on Kovan](/mcd/mcd-cli/mcd-cli-guide-01/mcd-cli-guide-01.md)
-- [Using Seth to create and close a Vault on Kovan](/mcd/mcd-seth/mcd-seth-01.md)
+- [Using Seth to create and close a Vault on Kovan](/mcd/mcd-seth/mcd-seth.md)
 - [Upgrading to MCD - overview for different partners](/mcd/upgrading-to-multi-collateral-dai/upgrading-to-multi-collateral-dai.md)
 - [Add a new collateral type - Kovan](/mcd/add-collateral-type-testnet/add-collateral-type-testnet.md)
 - [Intro to the Rate mechanism](/mcd/intro-rate-mechanism/intro-rate-mechanism.md)

--- a/mcd/README.md
+++ b/mcd/README.md
@@ -6,7 +6,7 @@ This repo contains guides for interacting and integrating with Multi-Collateral 
 
 - [Introduction and Overview of Maker Protocol](/mcd/mcd-101/mcd-101.md)
 - [Using MCD-CLI to create and close a Vault on Kovan](/mcd/mcd-cli/mcd-cli-guide-01/mcd-cli-guide-01.md)
-- [Using Seth to create and close a Vault on Kovan](/mcd/mcd-seth/mcd-seth.md)
+- [Using Seth to create and close a Vault on Goerli](/mcd/mcd-seth/mcd-seth.md)
 - [Upgrading to MCD - overview for different partners](/mcd/upgrading-to-multi-collateral-dai/upgrading-to-multi-collateral-dai.md)
 - [Add a new collateral type - Kovan](/mcd/add-collateral-type-testnet/add-collateral-type-testnet.md)
 - [Intro to the Rate mechanism](/mcd/intro-rate-mechanism/intro-rate-mechanism.md)

--- a/mcd/mcd-seth/mcd-seth.md
+++ b/mcd/mcd-seth/mcd-seth.md
@@ -409,8 +409,8 @@ Output:
 
 The WBTC is still assigned to the Vault, so we need to move them to our address:
 ```bash
-export wadC=$(seth --to-wei 5 eth)
-seth send $CDP_MANAGER 'flux(uint256, address, uint256)' $cdpId $ETH_FROM $wadC
+export wad=$(seth --to-wei 5 eth)
+seth send $CDP_MANAGER 'flux(uint256, address, uint256)' $cdpId $ETH_FROM $wad
 ```
 
 **NOTICE:** We are about to interact with the [join-5](https://goerli.etherscan.io/address/0x3cbE712a12e651eEAF430472c0C1BF1a2a18939D#code) adapter once again, so we need to bring `$WBTC_DECIMALS` back into the equation.

--- a/mcd/mcd-seth/mcd-seth.md
+++ b/mcd/mcd-seth/mcd-seth.md
@@ -1,6 +1,6 @@
 # Drawing Dai from the Goerli Maker Protocol deployment using Seth
 
-**⚠️ ATTENTION:** This guide works under the Goerli [1.11.0 Release](https://changelog.makerdao.com/releases/goerli/1.11.0/index.html) of the system.
+**⚠️ ATTENTION:** This guide works under the Goerli [1.11.0 Release](https://chainlog.makerdao.com/api/goerli/1.11.0.json) of the system.
 
 **ℹ️ NOTICE:** You can also use the Kovan, Rinkey and Ropsten deployments in this guide. Just make sure to change the contract addresses from the specific network.
 

--- a/mcd/mcd-seth/mcd-seth.md
+++ b/mcd/mcd-seth/mcd-seth.md
@@ -181,7 +181,7 @@ We'll be using the [CDP Manager](https://github.com/makerdao/dss-cdp-manager) as
 
 We begin by opening an empty Vault, so we can use it to lock collateral into. For this we need to define the type of collateral (WBTC-A) we want to lock in this Vault:
 ```bash
-export ilk=$(seth --to-bytes32 $(seth --from-ascii "WBTC-A"))
+export ilk=$(seth --to-bytes32 $(seth --from-ascii 'WBTC-A'))
 ```
 
 Now let’s open the Vault:
@@ -213,7 +213,7 @@ export amt=$(seth --from-fix $WBTC_DECIMALS 5)
 Then use the following command to use the join function, thus taking 5 WBTC from our account and sending to `urn` address.
 
 ```bash
-seth send $MCD_JOIN_WBTC_A "join(address, uint256)" $urn $amt
+seth send $MCD_JOIN_WBTC_A 'join(address, uint256)' $urn $amt
 ```
 
 **NOTICE:** From this point on, the [join-5](https://goerli.etherscan.io/address/0x3cbE712a12e651eEAF430472c0C1BF1a2a18939D#code) adapter already took care of the fact that WBTC has only 8 decimals, so we can proceed with `wad` normally.
@@ -303,7 +303,7 @@ seth send $MCD_VAT 'hope(address)' $MCD_JOIN_DAI
 
 And finally we exit the internal `dai` to the ERC-20 DAI:
 ```bash
-seth send $MCD_JOIN_DAI "exit(address, uint256)" $ETH_FROM $(seth --to-wei 15000 eth)
+seth send $MCD_JOIN_DAI 'exit(address, uint256)' $ETH_FROM $(seth --to-wei 15000 eth)
 ```
 
 And to check the DAI balance of our account:
@@ -341,8 +341,8 @@ export art=$(seth call $MCD_VAT 'urns(bytes32, address)(uint256 ink, uint256 art
 export rate=$(seth call $MCD_VAT \
     'ilks(bytes32)(uint256 Art, uint256 rate, uint256 spot, uint256 line, uint256 dust)' $ilk | \
     sed -n 2p | seth --to-fix $RAY_DECIMALS)
-export debt=$(bc<<<"$art*$rate")
-export debtWadRound=$(bc<<<"($art*$rate*10^${WAD_DECIMALS})/1 + 1")
+export debt=$(bc<<<"${art}*${rate}")
+export debtWadRound=$(bc<<<"(${art}*${rate}*10^${WAD_DECIMALS})/1 + 1")
 ```
 
 - `art`: internal vault debt representation
@@ -369,7 +369,7 @@ Output:
 Now to actually join the Dai to the adapter:
 
 ```bash
-seth send $MCD_JOIN_DAI "join(address, uint256)" $urn $debtWadRound
+seth send $MCD_JOIN_DAI 'join(address, uint256)' $urn $debtWadRound
 ```
 
 To make sure it all worked:
@@ -394,7 +394,7 @@ dart=$(seth --to-int256 -$(seth --to-wei $art eth))
 Again, we need to use the `frob` operation to change these parameters `frob(uint256 cdpId, address from, int dink, int dart)`:
 
 ```bash
-seth send $CDP_MANAGER "frob(uint256, int256, int256)" $cdpId $dink $dart
+seth send $CDP_MANAGER 'frob(uint256, int256, int256)' $cdpId $dink $dart
 ```
 
 This doesn’t mean we have already got back your tokens yet. Our account’s WBTC balance is not yet back to the original amount:
@@ -421,7 +421,7 @@ From there exit the WBTC adapter to get back our tokens:
 export WBTC_DECIMALS=8
 
 export amt=$(seth --from-fix $WBTC_DECIMALS 5)
-seth send $MCD_JOIN_WBTC_A "exit(address, uint256)" $ETH_FROM $amt
+seth send $MCD_JOIN_WBTC_A 'exit(address, uint256)' $ETH_FROM $amt
 ```
 
 If we check the balance again:

--- a/mcd/mcd-seth/mcd-seth.md
+++ b/mcd/mcd-seth/mcd-seth.md
@@ -333,9 +333,9 @@ seth send $MCD_JUG 'drip(bytes32)' $ilk
 First thing is to determine what is our debt, including the accrued stability fee:
 
 ```bash
-export RAD_DECIMALS=45
-export RAY_DECIMALS=27
 export WAD_DECIMALS=18
+export RAY_DECIMALS=27
+export RAD_DECIMALS=45
 
 export art=$(seth call $MCD_VAT 'urns(bytes32, address)(uint256 ink, uint256 art)' $ilk $urn | \
     sed -n 2p | seth --from-wei)

--- a/mcd/mcd-seth/mcd-seth.md
+++ b/mcd/mcd-seth/mcd-seth.md
@@ -2,7 +2,7 @@
 
 **This guide works under the Goerli [1.11.0 Release](https://changelog.makerdao.com/releases/goerli/1.11.0/index.html) of the system.**
 
-**You can also use the Rinkey, Ropsten and Goerli deployments in this guide. Just make sure to change the contract addresses from the specific network.**
+**You can also use the Kovan, Rinkey and Ropsten deployments in this guide. Just make sure to change the contract addresses from the specific network.**
 
 This tutorial will cover how to use the tool `seth` to deposit WBTC tokens to draw DAI from the Goerli deployment of MCD as an example, since the process is the same for any other ERC-20 token. You can use the same methodology for any supported token in MCD, by changing the contract addresses to the specific token you want to use.
 

--- a/mcd/mcd-seth/mcd-seth.md
+++ b/mcd/mcd-seth/mcd-seth.md
@@ -260,9 +260,9 @@ Learn more about naming in MCD [here](https://github.com/makerdao/dss/wiki/Gloss
 
 
 ```bash
-export RAD_DECIMALS=45
-export RAY_DECIMALS=27
 export WAD_DECIMALS=18
+export RAY_DECIMALS=27
+export RAD_DECIMALS=45
 
 export dink=$(seth --to-wei 5 eth)
 export rate=$(seth call $MCD_VAT \

--- a/mcd/mcd-seth/mcd-seth.md
+++ b/mcd/mcd-seth/mcd-seth.md
@@ -38,7 +38,6 @@ If using other networks, make sure to change the `SETH_CHAIN` and `ETH_RPC_URL` 
 
 ### Other tools
 
-- [`mcd-cli`](https://github.com/makerdao/mcd-cli#installation)
 - [`bc` (Arbitrary Precision Calculator)](https://www.gnu.org/software/bc/)
 
 ## Getting tokens
@@ -386,14 +385,13 @@ Output:
 Now, onto actually getting our collateral back. `dart` and `dink`, as the `d` in their abbreviation stands for delta, are inputs for changing a value, and thus they can be negative. When we want to lower the amount of DAI drawn from the `urn`, we lower the art parameter of the `urn`.
 
 We only need to set up the `dink` and `dart` variables.
-Using [mcd-cli](https://github.com/makerdao/mcd-cli#installation), we create our two negative `$dink` and `$dart`:
 
 ```bash
-dink=$(seth --to-uint256 $(mcd --to-hex $(seth --to-wei -5 eth)))
-dart=$(seth --to-uint256 $(mcd --to-hex -$(seth --to-wei $art eth)))
+dink=$(seth --to-int256 -$(seth --to-wei 5 eth))
+dart=$(seth --to-int256 -$(seth --to-wei $art eth))
 ```
 
-Again, we need to use the `frob` operation to change these parameters: `frob(uint256 cdpId, address from, int dink, int dart)`
+Again, we need to use the `frob` operation to change these parameters `frob(uint256 cdpId, address from, int dink, int dart)`:
 
 ```bash
 seth send $CDP_MANAGER "frob(uint256, int256, int256)" $cdpId $dink $dart

--- a/mcd/mcd-seth/mcd-seth.md
+++ b/mcd/mcd-seth/mcd-seth.md
@@ -38,7 +38,7 @@ If using other networks, make sure to change the `SETH_CHAIN` and `ETH_RPC_URL` 
 
 ### Other tools
 
-- [`bc` (Arbitrary Precision Calculator)](https://www.gnu.org/software/bc/)
+- [`bc` (Arbitrary Precision Calculator)](https://www.gnu.org/software/bc/).
 
 ## Getting tokens
 
@@ -173,7 +173,7 @@ In order to better understand the MCD contracts, the following provides a brief 
 - `art`: rate \* wad represented in DAI
 - `dart`: delta art – a signed difference value to the current value
 - `lad`: Vault owner
-- `rat`: collateralization ratio
+- `rat`: collateralization ratio.
 
 After giving permission to the WBTC adapter of MCD to take some of our tokens, it’s time to finally start using the MCD contracts.
 
@@ -199,12 +199,12 @@ export urn=$(seth call $CDP_MANAGER 'urns(uint256)(address)' $cdpId)
 After acquiring `cdpId` and `urn` address, we can move to the next step. Locking our tokens into the system.
 
 First we are going to make a transaction to the WBTC adapter to actually take 5 of our tokens with the join contract function.
-The contract function looks like the following: `join(address urn, uint256 amt)`
+The contract function looks like the following: `join(address urn, uint256 amt)`.
 
-- The first parameter is the `urn`, our vault address.
+- The first parameter is the `urn`, our vault address
 - The second parameter is the token amount in `wad`.
 
-For the sake of readability, we up the `amt` parameter representing the amount of collateral:
+For the sake of readability, we set the `amt` parameter representing the amount of collateral:
 
 ```bash
 export amt=$(seth --from-fix $WBTC_DECIMALS 5)
@@ -253,7 +253,7 @@ Inside the `vat`, different parameters have different decimal precisions:
 
 - `dai`: 45 decimals (`rad`)
 - `rate`: 27 decimals (`ray`)
-- `dink`/`dart`: 18 decimals (`wad`)
+- `dink`/`dart`: 18 decimals (`wad`).
 
 Learn more about naming in MCD [here](https://github.com/makerdao/dss/wiki/Glossary#general).
 

--- a/mcd/mcd-seth/mcd-seth.md
+++ b/mcd/mcd-seth/mcd-seth.md
@@ -55,6 +55,7 @@ export WBTC=0x7ccF0411c7932B99FC3704d68575250F032e3bB7
 ```
 
 **NOTICE:** `WBTC` has only 8 decimals instead of the standard 18 decimals, so keep this in mind when performing conversions, as `seth --to-wei/--from-wei` will not work. Use `seth --to-fix/--from-fix` instead.
+For tokens with 18 decimals, you can simply change the value of the variable below to `18` or use `seth --to-wei/--from-wei`.
 
 ```bash
 export WBTC_DECIMALS=8
@@ -182,7 +183,7 @@ We begin by opening an empty Vault, so we can use it to lock collateral into. Fo
 export ilk=$(seth --to-bytes32 $(seth --from-ascii "WBTC-A"))
 ```
 
-Now let's open the Vault:
+Now let’s open the Vault:
 ```bash
 seth send $CDP_MANAGER 'open(bytes32, address)' $ilk $ETH_FROM
 ```
@@ -259,9 +260,7 @@ With the variables set, we can call `frob`:
 seth send $CDP_MANAGER 'frob(uint256, int256, int256)' $cdpId $dink $dart
 ```
 
-Now, let's check out our internal DAI balance to see if we have succeeded.
-
-We are going to use the following `vat` function: `dai(address urn)(uint256)`:
+Now, let’s check out our internal DAI balance to see if we have succeeded. We are going to use the following `vat` function: `dai(address urn)(uint256)`:
 
 ```bash
 seth call $MCD_VAT 'dai(address)(uint256)' $urn | seth --to-fix 45

--- a/mcd/mcd-seth/mcd-seth.md
+++ b/mcd/mcd-seth/mcd-seth.md
@@ -1,20 +1,23 @@
-# Drawing Dai from the Kovan Maker Protocol deployment using Seth
+# Drawing Dai from the Goerli Maker Protocol deployment using Seth
 
-**This guide works under the Kovan [1.0.2 Release](https://changelog.makerdao.com/releases/kovan/1.0.2/index.html) of the system.**
-
-- [Drawing Dai from the Kovan Maker Protocol deployment using Seth](#drawing-dai-from-the-kovan-maker-protocol-deployment-using-seth)
-  - [Prerequisites](#prerequisites)
-    - [Setting up Seth](#setting-up-seth)
-    - [Other tools](#other-tools)
-  - [Getting tokens](#getting-tokens)
-  - [Saving contract addresses](#saving-contract-addresses)
-  - [Token approval](#token-approval)
-  - [Finally interacting with the Maker Protocol contracts](#finally-interacting-with-the-maker-protocol-contracts)
-  - [Paying back DAI debt to release collateral](#paying-back-dai-debt-to-release-collateral)
+**This guide works under the Goerli [1.11.0 Release](https://changelog.makerdao.com/releases/goerli/1.11.0/index.html) of the system.**
 
 **You can also use the Rinkey, Ropsten and Goerli deployments in this guide. Just make sure to change the contract addresses from the specific network.**
 
-This tutorial will cover how to use the tool `seth` to deposit BAT tokens to draw DAI from the Kovan deployment of MCD as an example, since the process is the same for any other ERC-20 token. You can use the same methodology for any supported token in MCD, by changing the contract addresses to the specific token you want to use.
+This tutorial will cover how to use the tool `seth` to deposit WBTC tokens to draw DAI from the Goerli deployment of MCD as an example, since the process is the same for any other ERC-20 token. You can use the same methodology for any supported token in MCD, by changing the contract addresses to the specific token you want to use.
+
+<!-- vim-markdown-toc GFM -->
+
+* [Prerequisites](#prerequisites)
+    * [Setting up Seth](#setting-up-seth)
+    * [Other tools](#other-tools)
+* [Getting tokens](#getting-tokens)
+* [Saving contract addresses](#saving-contract-addresses)
+* [Token approval](#token-approval)
+* [Finally interacting with the Maker Protocol contracts](#finally-interacting-with-the-maker-protocol-contracts)
+* [Paying back DAI debt to release collateral](#paying-back-dai-debt-to-release-collateral)
+
+<!-- vim-markdown-toc -->
 
 ## Prerequisites
 
@@ -24,11 +27,13 @@ For this guide, we are going to use the tool `seth`, to send transactions and in
 
 [Use this guide to install and set up Seth](https://github.com/makerdao/developerguides/blob/master/devtools/seth/seth-guide/seth-guide.md).
 
-**Note: Complete the above guide to setup your Seth environment variables and getting familiar with the tool before continuing. For this guide, we are using the Kovan Testnet. Ensure that Seth is configured to connect to Kovan by setting the network parameter accordingly in a terminal or config file:**
+**Note: Complete the above guide to set up your Seth environment variables and getting familiar with the tool before continuing. For this guide, we are using the Goerli Testnet. Ensure that Seth is configured to connect to Goerli by setting the network parameter accordingly in a terminal or config file:**
 
 **If using other networks, make sure to change the `SETH_CHAIN` and `ETH_RPC_URL` variables to your preferred network**
 
-`export SETH_CHAIN=kovan`
+```bash
+export SETH_CHAIN=goerli
+```
 
 ### Other tools
 
@@ -37,86 +42,121 @@ For this guide, we are going to use the tool `seth`, to send transactions and in
 
 ## Getting tokens
 
-Even though we are not using it as collateral, we will need Kovan ETH for gas. We can get some by following the guide here: [https://github.com/Kovan-testnet/faucet](https://github.com/kovan-testnet/faucet)
+Even though we are not using it as collateral, we will need Goerli ETH for gas. We can get some from this [faucet](https://goerlifaucet.com/).
 
-Next, we are going to need some test collateral tokens (BAT) on the Kovan network to draw DAI from them. Luckily, there is a faucet set up just for this. It gives the caller 50 BAT Kovan tokens.
+Next, we are going to need some test collateral tokens (WBTC) on the Goerli network to draw DAI from them. Luckily, there is a faucet set up just for this. It gives the caller 5 WBTC Goerli tokens.
 
-We can only call the faucet once per account address, so if you mess something up in the future or you need more for any reason, you are going to need to create a new account. This is how we can call the faucet with seth:
+We can only call the faucet once per account address, so if you mess something up in the future, or you require more for any reason, you are going to need to create a new account. This is how we can call the faucet with `seth`:
 
-**BAT ERC-20 token contract:**
+**WBTC ERC-20 token contract:**
 
-`export BAT=0x9f8cFB61D3B2aF62864408DD703F9C3BEB55dff7`
+```bash
+export WBTC=0x7ccF0411c7932B99FC3704d68575250F032e3bB7
+```
 
-**Token faucet on Kovan:**
+**NOTICE:** `WBTC` has only 8 decimals instead of the standard 18 decimals, so keep this in mind when performing conversions, as `seth --to-wei/--from-wei` will not work. Use `seth --to-fix/--from-fix` instead.
 
-`export FAUCET=0x57aAeAE905376a4B1899bA81364b4cE2519CBfB3`
+```bash
+export WBTC_DECIMALS=8
+```
 
-Execute the following to receive test 50 BAT tokens:
+**Token faucet on Goerli:**
 
-`seth send $FAUCET 'gulp(address)' $BAT`
+```bash
+export FAUCET=0xa473CdDD6E4FAc72481dc36f39A409D86980D187
+```
+
+Execute the following to receive test 5 WBTC tokens:
+
+```bash
+seth send $FAUCET 'gulp(address)' $WBTC
+```
 
 Let's check if we have received the tokens from the faucet. The following conversions are needed, because seth returns data in hexadecimal value, and the contract stores it in wei unit.
 
 Execute:
 
-`seth --from-wei $(seth --to-dec $(seth call $BAT 'balanceOf(address)' $ETH_FROM)) eth`
+```bash
+seth call $WBTC 'balanceOf(address)(uint256)' $ETH_FROM | seth --to-fix $WBTC_DECIMALS
+```
 
 If everything went according to plan, the output should be this:
 
-`50.000000000000000000`
-
-Note: We will need more than 50 BAT to be able to open a Vault large enough to generate the 20 minimum DAI required. The faucet won't provide more than 50 BAT per address but you may create additional addresses to accumulate the 130-150 BAT necessary.
+`5.00000000`
 
 ## Saving contract addresses
 
-For better readability, we are going to save a bunch of contract addresses in variables belonging to the related smart contracts deployed to Kovan. In a terminal, carry out the following commands (in grey):
+For better readability, we are going to save a bunch of contract addresses in variables belonging to the related smart contracts deployed to Goerli. In a terminal, carry out the following commands (in grey):
 
-**Set the gas quantity**  
-`export ETH_GAS=2000000`
+**Set the gas quantity:**  
+```bash
+export ETH_GAS=2000000
+```
 
-**BAT ERC-20 token contract:**
+**WBTC ERC-20 token contract:**
 
-`export BAT=0x9f8cFB61D3B2aF62864408DD703F9C3BEB55dff7`
+```bash
+export WBTC=0x7ccF0411c7932B99FC3704d68575250F032e3bB7
+```
 
 **DAI ERC-20 token contract:**
 
-`export DAI_TOKEN=0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa`
+```bash
+export MCD_DAI=0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844
+```
 
-**BAT-A token join adapter:**
+**WBTC-A token join adapter:**
 
-`export MCD_JOIN_BAT_A=0x2a4C485B1B8dFb46acCfbeCaF75b6188A59dBd0a`
+```bash
+export MCD_JOIN_WBTC_A=0x3cbE712a12e651eEAF430472c0C1BF1a2a18939D
+```
 
 **Vat contract - Central state storage for MCD:**
 
-`export MCD_VAT=0xbA987bDB501d131f766fEe8180Da5d81b34b69d9`
+```bash
+export MCD_VAT=0xB966002DDAa2Baf48369f5015329750019736031
+```
 
 **DAI token join adapter:**
 
-`export MCD_JOIN_DAI=0x5AA71a3ae1C0bd6ac27A1f28e1415fFFB6F15B8c`
+```bash
+export MCD_JOIN_DAI=0x6a60b7070befb2bfc964F646efDF70388320f4E0
+```
 
 **CDP Manager Contract:**
 
-`export CDP_MANAGER=0x1476483dD8C35F25e568113C5f70249D3976ba21`
+```bash
+export CDP_MANAGER=0xdcBf58c9640A7bd0e062f8092d70fb981Bb52032
+```
 
 **MCD JUG Contract:**
 
-`export MCD_JUG=0xcbB7718c9F39d05aEEDE1c472ca8Bf804b2f1EaD`
+```bash
+export MCD_JUG=0xC90C99FE9B5d5207A03b9F28A6E8A19C0e558916
+```
 
 ## Token approval
 
 We do not transfer ERC-20 tokens manually to the MCD adapters - instead we give approval for the adapters to using some of our ERC-20 tokens. The following section will take us through the necessary steps.
 
-In this example, we are going to use 150 BAT tokens to draw 20 DAI. You may of course use different amounts, just remember to change it accordingly in the function calls of this guide, while ensuring that you are within the accepted collateralization ratio of BAT Vault (150%) and the minimum vault debt (20 DAI). Let’s approve the use of 150 BAT tokens for the adapter, and then call the approve function of the BAT token contract with the right parameters. Again, we have to do some conversions, namely from `eth` unit to `wei`, then from decimal to hexadecimal (the `eth` keyword can be a bit confusing, but we are still dealing with BAT tokens. BAT has similar fraction values to ETH, so the keyword just means conversion to the whole token denomination):
+In this example, we are going to use 5 WBTC tokens to draw 15000 DAI. You may of course use different amounts, just remember to change it accordingly in the function calls of this guide, while ensuring that you are within the accepted collateralization ratio of WBTC Vault (145% at the time of this writing) and the minimum vault debt (15000 DAI). 
 
-`seth send $BAT 'approve(address,uint256)' $MCD_JOIN_BAT_A $(seth --to-uint256 $(seth --to-wei 150 eth))`
+Let’s approve the use of 5 WBTC tokens for the adapter, and then call the `approve` function of the WBTC token contract with the right parameters. Again, we have to do some conversions:
 
-If we want to be sure that our approve transaction succeeded, we can check the results with this command:
+```bash
+seth send $WBTC 'approve(address, uint256)' $MCD_JOIN_WBTC_A $(seth --from-fix $WBTC_DECIMALS 5)
+```
 
-`seth --from-wei $(seth --to-dec $(seth call $BAT 'allowance(address, address)' $ETH_FROM $MCD_JOIN_BAT_A)) eth`
+If we want to be sure that our approval transaction succeeded, we can check the results with this command:
+
+```bash
+seth call $WBTC 'allowance(address, address)(uint256)' $ETH_FROM $MCD_JOIN_WBTC_A | \
+    seth --to-fix $WBTC_DECIMALS
+```
 
 Output:
 
-`150.000000000000000000`
+`5.00000000`
 
 ## Finally interacting with the Maker Protocol contracts
 
@@ -133,117 +173,158 @@ In order to better understand the MCD contracts, the following provides a brief 
 - `lad`: Vault owner
 - `rat`: collateralization ratio
 
-After giving permission to the BAT adapter of MCD to take some of our tokens, it’s time to finally start using the MCD contracts.  
+After giving permission to the WBTC adapter of MCD to take some of our tokens, it’s time to finally start using the MCD contracts.
+
 We'll be using the [CDP Manager](https://github.com/makerdao/dss-cdp-manager) as the preferred interface to interact with MCD contracts.
 
-We begin by opening an empty Vault so we can use it to lock collateral into. For this we need to define the type of collateral (BAT-A) we want to lock in this Vault.  
-`export ilk=$(seth --to-bytes32 $(seth --from-ascii "BAT-A"))`  
-Now let's open the Vault  
-`seth send $CDP_MANAGER 'open(bytes32,address)' $ilk $ETH_FROM`
+We begin by opening an empty Vault, so we can use it to lock collateral into. For this we need to define the type of collateral (WBTC-A) we want to lock in this Vault:
+```bash
+export ilk=$(seth --to-bytes32 $(seth --from-ascii "WBTC-A"))
+```
 
-We need the `cdpId` and `urn` address of our open Vault so we can interact with the system.
+Now let's open the Vault:
+```bash
+seth send $CDP_MANAGER 'open(bytes32, address)' $ilk $ETH_FROM
+```
+
+We need the `cdpId` and `urn` address of our open Vault, so we can interact with the system.
 
 ```bash
-export cdpId=$(seth --to-dec $(seth call $CDP_MANAGER 'last(address)' $ETH_FROM))
-export urn=$(seth call $CDP_MANAGER 'urns(uint)(address)' $cdpId)
+export cdpId=$(seth call $CDP_MANAGER 'last(address)(uint256)' $ETH_FROM)
+export urn=$(seth call $CDP_MANAGER 'urns(uint256)(address)' $cdpId)
 ```
 
 After acquiring `cdpId` and `urn` address, we can move to the next step. Locking our tokens into the system.
-First we are going to make a transaction to the BAT adapter to actually take 10 of our tokens with the join contract function.
 
-The contract function looks like the following: `join(address urn, uint wad)`
+First we are going to make a transaction to the WBTC adapter to actually take 5 of our tokens with the join contract function.
+The contract function looks like the following: `join(address urn, uint256 wad)`
 
 - The first parameter is the `urn`, our vault address.
 - The second parameter is the token amount in `wad`.
 
-For the sake of readability, we up the `wadC` parameter representing the amount of collateral:
+For the sake of readability, we up the `amt` parameter representing the amount of collateral:
 
-`export wadC=$(seth --to-uint256 $(seth --to-wei 150 eth))`
+```bash
+export amt=$(seth --from-fix $WBTC_DECIMALS 5)
+```
 
-Then use the following command to use the join function, thus taking 150 BAT from our account and sending to `urn` address.
+Then use the following command to use the join function, thus taking 150 WBTC from our account and sending to `urn` address.
 
-`seth send $MCD_JOIN_BAT_A "join(address, uint)" $urn $wadC`
+```bash
+seth send $MCD_JOIN_WBTC_A "join(address, uint256)" $urn $amt
+```
 
-We can check the results with the contract function: `gem(bytes32 ilk,address urn)(uint256)` with.
+**NOTICE:** From this point on, the join adapter already took care of the fact that WBTC has only 8 decimals, so we can proceed with `wad` normally.
 
-`seth --from-wei $(seth call $MCD_VAT 'gem(bytes32,address)(uint256)' $ilk $urn) eth`
+We can check the results with the contract function: `gem(bytes32 ilk, address urn)(uint256)` with:
+
+```bash
+seth call $MCD_VAT 'gem(bytes32, address)(uint256)' $ilk $urn | seth --from-wei
+```
 
 The output should look like this:
 
-`150.000000000000000000`
+`5.000000000000000000`
 
-An optional, but recommended step is to invoke `jug.drip(ilk)` to make we are not paying undue stability fees. For more detail, please read the guide [Intro to the Rate mechanism](https://github.com/makerdao/developerguides/blob/master/mcd/intro-rate-mechanism/intro-rate-mechanism.md)
+An optional, but recommended step is to invoke `jug.drip(ilk)` to make we are not paying undue stability fees. For more detail, please read the guide [Intro to the Rate mechanism](../intro-rate-mechanism/intro-rate-mechanism.md).
 
-`seth send $MCD_JUG 'drip(bytes32)' $ilk`
+```bash
+seth send $MCD_JUG 'drip(bytes32)' $ilk
+```
 
 The next step is adding the collateral into an urn. This is done through the `CDP Manager` contract.
-The function is called `frob(uint256,uint256,uint256)`, which receives couple of parameters:
+
+The function is called `frob(uint256, uint256, uint256)`, which receives the following parameters:
 
 - `uint256 cdp` - the `cdpId`
 - `int256 dink` - delta ink (collateral)
 - `int256 dart` - delta art (Dai).
 
-If the `frob` operation is successful, it will adjust the corresponding data in the protected `vat` module. When adding collateral to an `urn`, `dink` needs to be the (positive) amount we want to add and `dart` needs to be the (positive) amount of DAI we want to draw. Let’s add our 150 BAT to the urn, and draw 20 DAI ensuring that the position is overcollateralized.
+If the `frob` operation is successful, it will adjust the corresponding data in the protected `vat` module. When adding collateral to an `urn`, `dink` needs to be the (positive) amount we want to add and `dart` needs to be the (positive) amount of DAI we want to draw. 
 
-We already set up `cdp` before, so we only need to set up `dink` (BAT deposit) and `dart` (DAI to be drawn):
-
-```bash
-dink=$(seth --to-uint256 $(seth --to-wei 150 eth))
-rate=$(seth --to-fix 27 $(seth --to-dec $(seth call $MCD_VAT 'ilks(bytes32)(uint256,uint256,uint256,uint256,uint256)' $ilk | sed -n 2p)))
-dart=$(seth --to-uint256 $(bc<<<"scale=18; art=(20/$rate*10^18+1); scale=0; art/1"))
-```
-
-- The `vat` is using an internal dai representation called "normalised art" that is useful to calculate accrued stability fees. To convert the Dai amount to normalized art, we have to divide it by the current ilk `rate`.
-
-With the variables set, we can call `frob`:  
-`seth send $CDP_MANAGER 'frob(uint256,int256,int256)' $cdpId $dink $dart`
-
-Now, let's check out our internal DAI balance to see if we have succeeded. We are going to use the following `vat` function: `dai(address urn)(uint256)`:
-
-`seth --to-fix 45 $(seth --to-dec $(seth call $MCD_VAT 'dai(address)(uint256)' $urn))`
-
-The output should look like this (The result isn't exactly 20 Dai because of number precision):
-
-`20.000000000000000000989957880534621130774523011`
-
-Now this DAI is minted, but the balance is still technically owned by the DAI adapter of MCD. If we actually want to use it, we have to transfer it to our account:
+Let’s add our 150 WBTC to the urn, and draw 15000 DAI ensuring that the position is overcollateralized.
+We already set up `cdp` before, so we only need to set up `dink` (WBTC deposit) and `dart` (DAI to be drawn):
 
 ```bash
-export rad=$(seth --to-dec $(seth call $MCD_VAT 'dai(address)(uint256)' $urn))
-seth send $CDP_MANAGER 'move(uint256,address,uint256)' $cdpId $ETH_FROM $(seth --to-uint256 $rad)
+dink=$(seth --to-wei 5 eth)
+rate=$(seth call $MCD_VAT 'ilks(bytes32)(uint256 Art, uint256 rate, uint256 spot, uint256 line, uint256 dust)' $ilk | \
+    sed -n 2p | seth --to-fix 27)
+dart=$(bc<<<"scale=18; art=(15000/$rate*10^18+1); scale=0; art/1")
 ```
 
-- Here, `rad`, is the total amount of DAI available in the `urn`. We are reading this number to get all the DAI possible.
+**NOTICE:** The `vat` is using an internal `dai` representation called "normalized art" that is useful to calculate accrued stability fees. To convert the Dai amount to normalized art, we have to divide it by the current ilk `rate`.
 
-We then permitting the Dai adapter to move Dai from VAT to our address:  
-`seth send $MCD_VAT 'hope(address)' $MCD_JOIN_DAI`
+With the variables set, we can call `frob`:
+```bash
+seth send $CDP_MANAGER 'frob(uint256, int256, int256)' $cdpId $dink $dart
+```
 
-An finally we exit the internal dai to the ERC-20 DAI:  
-`seth send $MCD_JOIN_DAI "exit(address,uint256)" $ETH_FROM $(seth --to-uint256 $(seth --to-wei 20 eth))`
+Now, let's check out our internal DAI balance to see if we have succeeded.
+
+We are going to use the following `vat` function: `dai(address urn)(uint256)`:
+
+```bash
+seth call $MCD_VAT 'dai(address)(uint256)' $urn | seth --to-fix 45
+```
+
+The output should look like this (The result isn't exactly 15000 Dai because of number precision):
+
+`15000.000000000000000000384361909233192325560636045`
+
+Now this DAI is minted, but the balance is still technically owned by the DAI adapter of MCD.
+
+If we actually want to use it, we have to transfer it to our account:
+
+```bash
+export rad=$(seth call $MCD_VAT 'dai(address)(uint256)' $urn)
+seth send $CDP_MANAGER 'move(uint256, address, uint256)' $cdpId $ETH_FROM $rad
+```
+
+**NOTICE:** Here, `rad`, is the total amount of DAI available in the `urn`. We are reading this number to get all the DAI possible.
+
+We now allow the Dai adapter to move Dai from VAT to our address:
+```bash
+seth send $MCD_VAT 'hope(address)' $MCD_JOIN_DAI
+```
+
+And finally we exit the internal `dai` to the ERC-20 DAI:
+```bash
+seth send $MCD_JOIN_DAI "exit(address, uint256)" $ETH_FROM $(seth --to-wei 15000 eth)
+```
 
 And to check the DAI balance of our account:
-
-`seth --from-wei $(seth --to-dec $(seth call $DAI_TOKEN 'balanceOf(address)' $ETH_FROM)) eth`
+```bash
+seth call $MCD_DAI 'balanceOf(address)(uint256)' $ETH_FROM | seth --from-wei
+```
 
 Expected output:
 
-`20.000000000000000000`
+`15000.000000000000000000`
 
-If everything checks out, congratulations: you have just acquired some multi-collateral DAI on Kovan!
+If everything checks out, congratulations: you have just acquired some multi-collateral DAI on Goerli!
 
 ## Paying back DAI debt to release collateral
 
-To pay back your DAI and release the locked collateral, follow the following steps. Please make sure to obtain some additional Dai (from another account or from another vault) because chances are interest will have accumulated in the meantime. To force stability fee accumulation, anyone can invoke `jug.drip(ilk)`:
+To pay back your DAI and release the locked collateral, follow the following steps. 
 
-`seth send $MCD_JUG 'drip(bytes32)' $ilk`
+**IMPORTANT:** Please make sure to **obtain some additional Dai** (from another account or from another vault) because chances are interest will have accumulated in the meantime.
+
+To force stability fee accumulation, anyone can invoke `jug.drip(ilk)`:
+
+```bash
+seth send $MCD_JUG 'drip(bytes32)' $ilk
+```
 
 First thing is to determine what is our debt, including the accrued stability fee:
 
 ```bash
-art=$(seth --from-wei $(seth --to-dec $(seth call $MCD_VAT 'urns(bytes32,address)(uint256,uint256)' $ilk $urn | sed -n 2p)))
-rate=$(seth --to-fix 27 $(seth --to-dec $(seth call $MCD_VAT 'ilks(bytes32)(uint256,uint256,uint256,uint256,uint256)' $ilk | sed -n 2p)))
+art=$(seth call $MCD_VAT 'urns(bytes32, address)(uint256 ink, uint256 art)' $ilk $urn | \
+    sed -n 2p | seth --from-wei)
+rate=$(seth call $MCD_VAT \
+    'ilks(bytes32)(uint256 Art, uint256 rate, uint256 spot, uint256 line, uint256 dust)' $ilk | \
+    sed -n 2p | seth --to-fix 27)
 debt=$(bc<<<"$art*$rate")
-debtWadRound=$(seth --to-uint256 $(bc<<<"$art*$rate*10^18/1+1"))
+debtWadRound=$(bc<<<"($art*$rate*10^18)/1 + 1")
 ```
 
 - `art`: internal vault debt representation
@@ -251,66 +332,86 @@ debtWadRound=$(seth --to-uint256 $(bc<<<"$art*$rate*10^18/1+1"))
 - `debt`: vault debt in Dai
 - `debtWadRound`: vault debt in wad (i.e. multiplied by 10^18), added by 1 wad to avoid rounding issues.
 
-Then we need to approve the transfer of DAI tokens to the adapter. Call the approve function of the DAI ERC-20 token contract with the right parameters:
+Then we need to approve the transfer of DAI tokens to the adapter. Call the `approve` function of the DAI ERC-20 token contract with the right parameters:
 
-`seth send $DAI_TOKEN 'approve(address,uint256)' $MCD_JOIN_DAI $debtWadRound`
+```bash
+seth send $MCD_DAI 'approve(address, uint256)' $MCD_JOIN_DAI $debtWadRound
+```
 
-If we want to be sure that our approve transaction succeeded, we can check the results with this command:
+If we want to be sure that our approval transaction succeeded, we can check the results with this command:
 
-`seth --from-wei $(seth --to-dec $(seth call $DAI_TOKEN 'allowance(address, address)' $ETH_FROM $MCD_JOIN_DAI)) eth`
+```bash
+seth call $MCD_DAI 'allowance(address, address)(uint256)' $ETH_FROM $MCD_JOIN_DAI | seth --from-wei
+```
 
 Output:
 
-`20.000000000000000001`
+`15000.041850037339693452`
 
 Now to actually join the Dai to the adapter:
 
-`seth send $MCD_JOIN_DAI "join(address,uint)" $urn $debtWadRound`
+```bash
+seth send $MCD_JOIN_DAI "join(address, uint256)" $urn $debtWadRound
+```
 
 To make sure it all worked:
 
-`seth --to-fix 45 $(seth --to-dec $(seth call $MCD_VAT 'dai(address)(uint256)' $urn))`
+```bash
+seth call $MCD_VAT 'dai(address)(uint256)' $urn | seth --to-fix 45
+```
 
 Output:
 
-`20.000000000000000001000000000000000000000000000`
+`15000.041850037339693452000000000000000000000000000`
 
-Now, onto actually getting our collateral back. `dart` and `dink`, as the d in their abbreviation stands for delta, are inputs for changing a value, and thus they can be negative. When we want to lower the amount of DAI drawn from the `urn`, we lower the art parameter of the `urn`. Again, we need to use the `frob` operation to change these parameters: `frob(uint cdpId, address ETH_FROM, int dink, int dart)`
+Now, onto actually getting our collateral back. `dart` and `dink`, as the `d` in their abbreviation stands for delta, are inputs for changing a value, and thus they can be negative. When we want to lower the amount of DAI drawn from the `urn`, we lower the art parameter of the `urn`.
 
 We only need to set up the `dink` and `dart` variables.
-
-Using [mcd-cli](https://github.com/makerdao/mcd-cli#installation), we create our two negative `$dink` and `$dart`.
+Using [mcd-cli](https://github.com/makerdao/mcd-cli#installation), we create our two negative `$dink` and `$dart`:
 
 ```bash
-dink=$(seth --to-uint256 $(mcd --to-hex $(seth --to-wei -150 eth)))
+dink=$(seth --to-uint256 $(mcd --to-hex $(seth --to-wei -5 eth)))
 dart=$(seth --to-uint256 $(mcd --to-hex -$(seth --to-wei $art eth)))
 ```
 
-And execute:
+Again, we need to use the `frob` operation to change these parameters: `frob(uint256 cdpId, address ETH_FROM, int dink, int dart)`
 
-`seth send $CDP_MANAGER "frob(uint256,int256,int256)" $cdpId $dink $dart`
+```bash
+seth send $CDP_MANAGER "frob(uint256, int256, int256)" $cdpId $dink $dart
+```
 
-This doesn’t mean we have already got back your tokens yet. Our account’s BAT balance is not yet back to the original amount:
+This doesn’t mean we have already got back your tokens yet. Our account’s WBTC balance is not yet back to the original amount:
 
-`seth --from-wei $(seth --to-dec $(seth call $BAT 'balanceOf(address)' $ETH_FROM)) eth`
+```bash
+seth call $WBTC 'balanceOf(address)(uint256)' $ETH_FROM | seth --to-fix $WBTC_DECIMALS
+```
 
 Output:
 
-`0.000000000000000000`
+`0.00000000`
 
-The BAT is still assigned to the Vault, so we need to move them to our address:
-`seth send $CDP_MANAGER 'flux(uint256,address,uint256)' $cdpId $ETH_FROM $wadC`
+The WBTC is still assigned to the Vault, so we need to move them to our address:
+```bash
+wadC=$(seth --to-wei 5 eth)
+seth send $CDP_MANAGER 'flux(uint256, address, uint256)' $cdpId $ETH_FROM $wadC
+```
 
-And from there exit the BAT adapter to get back our tokens:
+And from there exit the WBTC adapter to get back our tokens:
 
-`seth send $MCD_JOIN_BAT_A "exit(address, uint)" $ETH_FROM $wadC`
+```bash
+seth send $MCD_JOIN_WBTC_A "exit(address, uint256)" $ETH_FROM $amt
+```
 
 If we check the balance again:
 
-`seth --from-wei $(seth --to-dec $(seth call $BAT 'balanceOf(address)' $ETH_FROM)) eth`
+```bash
+seth call $WBTC 'balanceOf(address)(uint256)' $ETH_FROM | seth --to-fix $WBTC_DECIMALS
+```
 
 Output:
 
-`150.000000000000000000`
+`5.00000000`
 
-Yay, you got back your tokens! If you have come this far, congratulations, you have finished paying back the debt of your Vault in Multi-Collateral Dai and getting back the collateral. Spend those freshly regained test BAT tokens wisely!
+Yay, you got back your tokens! If you have come this far, congratulations, you have finished paying back the debt of your Vault in Multi-Collateral Dai and getting back the collateral.
+
+Spend those freshly regained test WBTC tokens wisely!

--- a/mcd/mcd-seth/mcd-seth.md
+++ b/mcd/mcd-seth/mcd-seth.md
@@ -113,7 +113,7 @@ export MCD_DAI=0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844
 export MCD_JOIN_WBTC_A=0x3cbE712a12e651eEAF430472c0C1BF1a2a18939D
 ```
 
-**Vat contract &ndash; Central state storage for MCD:**
+**Vat contract – Central state storage for MCD:**
 
 ```bash
 export MCD_VAT=0xB966002DDAa2Baf48369f5015329750019736031
@@ -139,9 +139,9 @@ export MCD_JUG=0xC90C99FE9B5d5207A03b9F28A6E8A19C0e558916
 
 ## Token approval
 
-We do not transfer ERC-20 tokens manually to the MCD adapters &ndash; instead we give approval for the adapters to using some of our ERC-20 tokens. The following section will take us through the necessary steps.
+We do not transfer ERC-20 tokens manually to the MCD adapters – instead we give approval for the adapters to using some of our ERC-20 tokens. The following section will take us through the necessary steps.
 
-In this example, we are going to use 5 WBTC tokens to draw 15000 DAI. You may of course use different amounts, just remember to change it accordingly in the function calls of this guide, while ensuring that you are within the accepted collateralization ratio (`mat`) of a WBTC Vault and the minimum vault debt (`dust`) &ndash; respectively, `145%` and `15000` DAI at the time of this writing.
+In this example, we are going to use 5 WBTC tokens to draw 15000 DAI. You may of course use different amounts, just remember to change it accordingly in the function calls of this guide, while ensuring that you are within the accepted collateralization ratio (`mat`) of a WBTC Vault and the minimum vault debt (`dust`) – respectively, `145%` and `15000` DAI at the time of this writing.
 
 Let’s approve the use of 5 WBTC tokens for the adapter, and then call the `approve` function of the WBTC token contract with the right parameters. Again, we have to do some conversions:
 
@@ -167,11 +167,11 @@ In order to better understand the MCD contracts, the following provides a brief 
 - `wad`: token unit amount
 - `gem`: collateral token adapter
 - `ilk`: Vault type
-- `urn`: Vault record &ndash; keeps track of a Vault
+- `urn`: Vault record – keeps track of a Vault
 - `ink`: rate \* wad represented in collateral
-- `dink`: delta ink &ndash; a signed difference value to the current value
+- `dink`: delta ink – a signed difference value to the current value
 - `art`: rate \* wad represented in DAI
-- `dart`: delta art &ndash; a signed difference value to the current value
+- `dart`: delta art – a signed difference value to the current value
 - `lad`: Vault owner
 - `rat`: collateralization ratio
 
@@ -238,9 +238,9 @@ The next step is adding the collateral into an urn. This is done through the `CD
 
 The function is called `frob(uint256, uint256, uint256)`, which receives the following parameters:
 
-- `uint256 cdp` &ndash; the `cdpId`
-- `int256 dink` &ndash; delta ink (collateral)
-- `int256 dart` &ndash; delta art (Dai).
+- `uint256 cdp`: the `cdpId`
+- `int256 dink`: delta ink (collateral)
+- `int256 dart`: delta art (Dai).
 
 If the `frob` operation is successful, it will adjust the corresponding data in the protected `vat` module. When adding collateral to an `urn`, `dink` needs to be the (positive) amount we want to add and `dart` needs to be the (positive) amount of DAI we want to draw. 
 

--- a/mcd/mcd-seth/mcd-seth.md
+++ b/mcd/mcd-seth/mcd-seth.md
@@ -6,8 +6,6 @@
 
 This tutorial will cover how to use the tool `seth` to deposit WBTC tokens to draw DAI from the Goerli deployment of MCD as an example, since the process is the same for any other ERC-20 token. You can use the same methodology for any supported token in MCD, by changing the contract addresses to the specific token you want to use.
 
-<!-- vim-markdown-toc GFM -->
-
 * [Prerequisites](#prerequisites)
     * [Setting up Seth](#setting-up-seth)
     * [Other tools](#other-tools)
@@ -16,8 +14,6 @@ This tutorial will cover how to use the tool `seth` to deposit WBTC tokens to dr
 * [Token approval](#token-approval)
 * [Finally interacting with the Maker Protocol contracts](#finally-interacting-with-the-maker-protocol-contracts)
 * [Paying back DAI debt to release collateral](#paying-back-dai-debt-to-release-collateral)
-
-<!-- vim-markdown-toc -->
 
 ## Prerequisites
 

--- a/mcd/mcd-seth/mcd-seth.md
+++ b/mcd/mcd-seth/mcd-seth.md
@@ -1,8 +1,8 @@
 # Drawing Dai from the Goerli Maker Protocol deployment using Seth
 
-**This guide works under the Goerli [1.11.0 Release](https://changelog.makerdao.com/releases/goerli/1.11.0/index.html) of the system.**
+**⚠️ ATTENTION:** This guide works under the Goerli [1.11.0 Release](https://changelog.makerdao.com/releases/goerli/1.11.0/index.html) of the system.
 
-**You can also use the Kovan, Rinkey and Ropsten deployments in this guide. Just make sure to change the contract addresses from the specific network.**
+**ℹ️ NOTICE:** You can also use the Kovan, Rinkey and Ropsten deployments in this guide. Just make sure to change the contract addresses from the specific network.
 
 This tutorial will cover how to use the tool `seth` to deposit WBTC tokens to draw DAI from the Goerli deployment of MCD as an example, since the process is the same for any other ERC-20 token. You can use the same methodology for any supported token in MCD, by changing the contract addresses to the specific token you want to use.
 
@@ -54,7 +54,7 @@ We can only call the faucet once per account address, so if you mess something u
 export WBTC=0x7ccF0411c7932B99FC3704d68575250F032e3bB7
 ```
 
-**NOTICE:** `WBTC` has only 8 decimals instead of the standard 18 decimals, so keep this in mind when performing conversions, as `seth --to-wei/--from-wei` will not work. Use `seth --to-fix/--from-fix` instead.
+**ℹ️ NOTICE:** `WBTC` has only 8 decimals instead of the standard 18 decimals, so keep this in mind when performing conversions, as `seth --to-wei/--from-wei` will not work. Use `seth --to-fix/--from-fix` instead.
 For tokens with 18 decimals, you can simply change the value of the variable below to `18` or use `seth --to-wei/--from-wei`.
 
 ```bash
@@ -216,7 +216,7 @@ Then use the following command to use the join function, thus taking 5 WBTC from
 seth send $MCD_JOIN_WBTC_A 'join(address, uint256)' $urn $amt
 ```
 
-**NOTICE:** From this point on, the [join-5](https://goerli.etherscan.io/address/0x3cbE712a12e651eEAF430472c0C1BF1a2a18939D#code) adapter already took care of the fact that WBTC has only 8 decimals, so we can proceed with `wad` normally.
+**ℹ️ NOTICE:** From this point on, the [join-5](https://goerli.etherscan.io/address/0x3cbE712a12e651eEAF430472c0C1BF1a2a18939D#code) adapter already took care of the fact that WBTC has only 8 decimals, so we can proceed with `wad` normally.
 
 We can check the results with the contract function: `gem(bytes32 ilk, address urn)(uint256)` with:
 
@@ -247,7 +247,7 @@ If the `frob` operation is successful, it will adjust the corresponding data in 
 Let’s add our 5 WBTC to the urn, and draw 15000 DAI ensuring that the position is overcollateralized.
 We already set up `cdp` before, so we only need to set up `dink` (WBTC deposit) and `dart` (DAI to be drawn):
 
-**NOTICE:** The `vat` uses an internal `dai` representation called &ldquo;normalized art&rdquo; that is useful to calculate accrued stability fees. To convert the Dai amount to normalized art, we have to divide it by the current ilk `rate`.
+**ℹ️ NOTICE:** The `vat` uses an internal `dai` representation called “normalized art” that is useful to calculate accrued stability fees. To convert the Dai amount to normalized art, we have to divide it by the current ilk `rate`.
 
 Inside the `vat`, different parameters have different decimal precisions:
 
@@ -294,7 +294,7 @@ export rad=$(seth call $MCD_VAT 'dai(address)(uint256)' $urn)
 seth send $CDP_MANAGER 'move(uint256, address, uint256)' $cdpId $ETH_FROM $rad
 ```
 
-**NOTICE:** Here, `rad`, is the total amount of DAI available in the `urn`. We are reading this number to get all the DAI possible.
+**ℹ️ NOTICE:** Here, `rad`, is the total amount of DAI available in the `urn`. We are reading this number to get all the DAI possible.
 
 We now allow the Dai adapter to move Dai from VAT to our address:
 ```bash
@@ -321,7 +321,7 @@ If everything checks out, congratulations: you have just acquired some multi-col
 
 To pay back your DAI and release the locked collateral, follow the following steps. 
 
-**IMPORTANT:** Please make sure to **obtain some additional Dai** (from another account or from another vault) because chances are interest will have accumulated in the meantime.
+**⚠️ ATTENTION:** Please make sure to **obtain some additional Dai** (from another account or from another vault) because chances are interest will have accumulated in the meantime.
 
 To force stability fee accumulation, anyone can invoke `jug.drip(ilk)`:
 
@@ -413,7 +413,7 @@ export wad=$(seth --to-wei 5 eth)
 seth send $CDP_MANAGER 'flux(uint256, address, uint256)' $cdpId $ETH_FROM $wad
 ```
 
-**NOTICE:** We are about to interact with the [join-5](https://goerli.etherscan.io/address/0x3cbE712a12e651eEAF430472c0C1BF1a2a18939D#code) adapter once again, so we need to bring `$WBTC_DECIMALS` back into the equation.
+**ℹ️ NOTICE:** We are about to interact with the [join-5](https://goerli.etherscan.io/address/0x3cbE712a12e651eEAF430472c0C1BF1a2a18939D#code) adapter once again, so we need to bring `$WBTC_DECIMALS` back into the equation.
 
 From there exit the WBTC adapter to get back our tokens:
 


### PR DESCRIPTION
- [x] Replace all addresses to use the latest Goerli environment instead of Kovan.
- [x] Replace `BAT-A` by `WBTC-A` as the ilk used for the examples.
- [x] Streamline some `seth` calls, getting rid of redundant/unnecessary calls.
- [x] Fix some `seth --to-dec` calls causing problems when the data was already in the decimal format.
- [x] Improve general markdown structure.
- [x] Fix some typos.